### PR TITLE
Fix pkgconfig libdir path

### DIFF
--- a/fc-solve/source/libfreecell-solver.pc.in
+++ b/fc-solve/source/libfreecell-solver.pc.in
@@ -1,6 +1,6 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/lib@LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name:  Freecell Solver


### PR DESCRIPTION
Needs to respect LIB_SUFFIX to work.

Ideally this would all use GNUInstallDirs but that is for another day.