### PR TITLE
Remove the unused sys/cdefs.h include

### DIFF
--- a/fc-solve/source/sys/tree.h
+++ b/fc-solve/source/sys/tree.h
@@ -29,9 +29,6 @@
 #pragma once
 
 #include "rinutils/unused.h"
-#ifndef _WIN32
-#include <sys/cdefs.h>
-#endif
 
 /*
  * This file defines data structures for different types of trees:


### PR DESCRIPTION
The header is internal to glibc and prevents compilation on non-glibc systems. Since it is not used anywhere, it can be safely removed.

Fixes shlomif/fc-solve#97